### PR TITLE
Do not catch everything

### DIFF
--- a/include/directional/write_raw_field.h
+++ b/include/directional/write_raw_field.h
@@ -16,36 +16,27 @@
 namespace directional
 {
 
-	// Writes a a directional field in raw format to file
-	// Inputs:
-	//   filename: The name used for the mesh and singularity file, without extention
+  // Writes a a directional field in raw format to file
+  // Inputs:
+  //   filename: The name used for the mesh and singularity file, without extention
   //   rawField: #F by 3*N in xyzxyz format (N is derived from F.cols())
   // Returns:
-	//   Whether or not the file was written successfully
-	bool IGL_INLINE write_raw_field(const std::string fileName, Eigen::MatrixXd& rawField)
-	{
-    
-  try
+  //   Whether or not the file was written successfully
+  bool IGL_INLINE write_raw_field(const std::string fileName, Eigen::MatrixXd& rawField)
   {
-    std::ofstream f(fileName);
-    
-    int N=rawField.cols()/3;
-    assert(3*N==rawField.cols());
-    f<<N<<" "<<rawField.rows()<<std::endl;
-    for (int i=0;i<rawField.rows();i++){
-      for (int j=0;j<rawField.cols();j++)
-        f<<rawField(i,j)<<" ";
-      f<<std::endl;
-    }
-    f.close();
-    return !f.fail();
+      std::ofstream f(fileName);
+      int N = rawField.cols() / 3;
+      assert(3 * N == rawField.cols());
+      f << N << " " << rawField.rows() << std::endl;
+      for (int i=0;i<rawField.rows();i++)
+      {
+        for (int j=0;j<rawField.cols();j++)
+          f << rawField(i,j) << " ";
+        f << std::endl;
+      }
+      f.close();
+      return !f.fail();
   }
-  catch (std::exception e)
-  {
-    return false;
-  }
-}
-  
 }
 
 #endif

--- a/include/directional/write_singularities.h
+++ b/include/directional/write_singularities.h
@@ -29,21 +29,14 @@ namespace directional
                                       const Eigen::VectorXi &singVertices,
                                       const Eigen::VectorXi &singIndices)
   {
-    try
-    {
       std::ofstream f(fileName, std::ios::trunc);
-      f<<N<<" "<<singIndices.size()<<std::endl;
+      f << N << " " << singIndices.size() < <std::endl;
       
       for (int i=0;i<singIndices.rows();i++)
-        f<<singVertices(i)<<" "<<singIndices(i)<<std::endl;
+        f << singVertices(i) << " " << singIndices(i) << std::endl;
       
       f.close();
       return !f.fail();
-    }
-    catch(std::exception e)
-    {
-      return false;
-    }
   }
 }
 


### PR DESCRIPTION
Catching all the possible exceptions is a bad practice and it should avoided. In my opinion, there is no need to catch everything here, moreover letting the code to crash with proper error messages can help to find bugs in the user code.