### PR TITLE
fix the status returned by the field read function

### DIFF
--- a/include/directional/read_raw_field.h
+++ b/include/directional/read_raw_field.h
@@ -32,6 +32,9 @@ namespace directional
     try
     {
       std::ifstream f(fileName);
+      if (!f.is_open()) {
+          return false;
+      }
       int numF;
       f>>N;
       f>>numF;

--- a/include/directional/read_raw_field.h
+++ b/include/directional/read_raw_field.h
@@ -43,7 +43,7 @@ namespace directional
           f>>rawField(i,j);
       
       f.close();
-      return f.fail();
+      return f.good();
     }
     catch (std::exception e)
     {


### PR DESCRIPTION
as in the description. The values returned by the fail() method have another meaning than indented here.