### PR TITLE
fix compilation errors

### DIFF
--- a/include/directional/write_singularities.h
+++ b/include/directional/write_singularities.h
@@ -30,7 +30,7 @@ namespace directional
                                       const Eigen::VectorXi &singIndices)
   {
       std::ofstream f(fileName, std::ios::trunc);
-      f << N << " " << singIndices.size() < <std::endl;
+      f << N << " " << singIndices.size() << std::endl;
       
       for (int i=0;i<singIndices.rows();i++)
         f << singVertices(i) << " " << singIndices(i) << std::endl;


### PR DESCRIPTION
an extra space caused compilation errors with gcc.